### PR TITLE
fix: モバイルでヘッダーが縦にはみ出る問題を修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,7 +130,7 @@ export default function Home() {
   }
 
   return (
-    <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
+    <div className="flex h-dvh bg-gray-50 dark:bg-gray-950">
       {/* モバイル：サイドバー背景暗幕 */}
       {sidebarOpen && (
         <div


### PR DESCRIPTION
## Summary
- `h-screen`（100vh）をモバイルブラウザのアドレスバーを考慮した `h-dvh` に変更

## 原因
`100vh` はiOS/Androidのブラウザアドレスバーの高さを含めて計算されるため、実際の表示領域をオーバーしコンテンツが縦にはみ出ていた。

## Test plan
- [ ] スマホでアクセスし、ヘッダー・チャットエリア・入力フォームが画面内に収まることを確認
- [ ] スクロール時にアドレスバーが収縮した場合も正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)