### PR TITLE
fix: SSEストリームのJSONパースにtry-catchを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,13 +71,17 @@ export default function Home() {
 
       const reader = res.body!.getReader();
       const decoder = new TextDecoder();
+      let lineBuffer = "";
 
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 
-        const chunk = decoder.decode(value, { stream: true });
-        for (const line of chunk.split("\n")) {
+        lineBuffer += decoder.decode(value, { stream: true });
+        const lines = lineBuffer.split("\n");
+        lineBuffer = lines.pop() ?? ""; // 最後の不完全な行を次チャンクに持ち越す
+
+        for (const line of lines) {
           if (!line.startsWith("data: ")) continue;
           let event: { type: string; content: unknown };
           try {
@@ -87,6 +91,7 @@ export default function Home() {
           }
 
           if (event.type === "token") {
+            if (typeof event.content !== "string") continue;
             setMessages((prev) => {
               const updated = [...prev];
               updated[updated.length - 1] = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,7 +79,12 @@ export default function Home() {
         const chunk = decoder.decode(value, { stream: true });
         for (const line of chunk.split("\n")) {
           if (!line.startsWith("data: ")) continue;
-          const event = JSON.parse(line.slice(6));
+          let event: { type: string; content: unknown };
+          try {
+            event = JSON.parse(line.slice(6));
+          } catch {
+            continue;
+          }
 
           if (event.type === "token") {
             setMessages((prev) => {


### PR DESCRIPTION
## 概要

SSEストリームの処理中に不正なJSONが来た場合、`JSON.parse` が例外をスローしてストリーム全体が中断される問題を修正。

## 変更内容

- `src/app/page.tsx` の `handleSubmit` 内 for...of ループで、`JSON.parse` を `try-catch` で囲むように変更
- パースに失敗した行は `continue` でスキップし、残りのストリーム処理を継続する

close #4

## テスト

- `npm run build` でビルドが正常に通ることを確認済み